### PR TITLE
set default value of splitAllowed=true

### DIFF
--- a/graphgrid-sdk-java-fuze/src/main/java/com/graphgrid/sdk/model/neo4jWriter/TransactionRequest.java
+++ b/graphgrid-sdk-java-fuze/src/main/java/com/graphgrid/sdk/model/neo4jWriter/TransactionRequest.java
@@ -32,7 +32,7 @@ public class TransactionRequest
     private long startTime;
     private long endTime;
 
-    private boolean splitAllowed;
+    private boolean splitAllowed = true;
 
     private List<TransactionRequest> children;
     private Integer errorIndex;


### PR DESCRIPTION
Transactions will not be retried when `splitAllowed=false`, so set `splitAllowed=true` by default.